### PR TITLE
Change default encoding manager

### DIFF
--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -87,5 +87,5 @@
 
 //advanced settings, you can probably leave these
 #define ENCODING 1
-#define ENCODE_LEGACY 0
-#define ENCODE_ALPHA  1
+#define ENCODE_LEGACY 1
+#define ENCODE_ALPHA  0

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -86,6 +86,6 @@
 #endif
 
 //advanced settings, you can probably leave these
-#define ENCODING 1
-#define ENCODE_LEGACY 1
-#define ENCODE_ALPHA  0
+#define ENCODING 0
+#define ENCODE_LEGACY 0
+#define ENCODE_ALPHA  1


### PR DESCRIPTION
The new encoding method hasn't been introduced in the driver yet - set the legacy one as default for now.