### PR TITLE
Median filtering, and analog value clamping

### DIFF
--- a/firmware/lucidgloves-firmware/AdvancedConfig.h
+++ b/firmware/lucidgloves-firmware/AdvancedConfig.h
@@ -26,5 +26,7 @@
 #define CLAMP_MIN 0  //the minimum value from the flexion sensors
 #define CLAMP_MAX 4095  //the maximum value from the flexion sensors
 
+// You must install RunningMedian library to use this feature
+// https://www.arduino.cc/reference/en/libraries/runningmedian/
 #define ENABLE_MEDIAN_FILTER false //use the median of the previous values, helps reduce noise
 #define MEDIAN_SAMPLES 20

--- a/firmware/lucidgloves-firmware/AdvancedConfig.h
+++ b/firmware/lucidgloves-firmware/AdvancedConfig.h
@@ -18,3 +18,13 @@
 #define MIDDLE_IND 2
 #define INDEX_IND 1
 #define THUMB_IND 0
+
+//Filtering and clamping analog inputs
+#define CLAMP_ANALOG_MAP true //clamp the mapped analog values from 0 to ANALOG_MAX
+
+#define CLAMP_FLEXION false  //clamp the raw flexion values
+#define CLAMP_MIN 0  //the minimum value from the flexion sensors
+#define CLAMP_MAX 4095  //the maximum value from the flexion sensors
+
+#define ENABLE_MEDIAN_FILTER false //use the median of the previous values, helps reduce noise
+#define MEDIAN_SAMPLES 20

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -1,4 +1,4 @@
-// RunningMedian by Rob Tillaart
+// Requires RunningMedian library by Rob Tillaart
 #if ENABLE_MEDIAN_FILTER
   #include <RunningMedian.h>
   RunningMedian rmSamples[5] = {


### PR DESCRIPTION
I've added an optional median filter using the RunningMedian library (https://github.com/RobTillaart/RunningMedian), which can help filtering noisy sensors like bend/flex sensors or hall sensors.  Default disabled, and the library only needs to be installed if enabled.

I've also added clamps to the values produced by mapping the analogRead() output against the 0 .. ANALOG_MAX range, which helps when constant calibration is disabled to prevent under or overflow.  Defaults enabled.

Additionally I've added clamps to the possible flexion min and max values, which helps with my bend and hall sensor gloves which can occasionally produce spurious output that reach past the normal min/max values.  This lets you tune the possible range of calibration values and prevents the min/max used in the map from going out of control.  Defaults disabled.

Finally, I've replaced the math being done to calibrate across the 0 .. ANALOG_MAX range with the arduino map() function, for simplicity. I've verified that the values produced by the original equation and those produced by the map() function are identical, so this should not produce a functional change.