### PR TITLE
Updates the lucidgloves-firmware readme and adds a readme to lucidgloves-hardware

### DIFF
--- a/firmware/lucidgloves-firmware/README.md
+++ b/firmware/lucidgloves-firmware/README.md
@@ -1,17 +1,4 @@
 # lucidgloves-firmware
 
-## Adding Required ESP-32 Libraries
-Using ESP-32 Dev Boards, which is required if you want to use Bluetooth Serial to connect your gloves wirelessly, requires you to install additional packages to your arduino IDE. Below is a procedure for doing so.
 
-1. Go to File > Prefrences in your Arduino IDE
-2. In the "Additional Board Manager URLs" field, enter this link: https://dl.espressif.com/dl/package_esp32_index.json and click the OK button
-3. Go to Tools > Board > Boards Manager
-4. Search "esp32" and install the "ESP32 by Espressif Systems" package.
-5. Select your ESP32 board from Tools > Board
-6. Download the ESP32 Arduino Servo Library from this link: https://github.com/RoboticsBrno/ESP32-Arduino-Servo-Library/archive/master.zip
-7. Unzip the downloaded folder
-8. Rename the folder from ESP32-Arduino-Servo-Library-Master to ESP32_Arduino_Servo_Library
-9. Move the ESP32_Arduino_Servo_Library folder to your Arduino IDE installation libraries folder
-10. Restart your IDE
-
-All of your packages should be installed and ready to go.
+Check the [Wiki](https://github.com/LucidVR/lucidgloves/wiki/Firmware-Setup-and-Customization-Tutorial/) for instructions on how to set it up.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,8 @@
+# lucidgloves-hardware
+
+
+Here are the 3D models for your printed glove parts.
+The x.1 versions have slight tweaks over their counterparts to make them more easily printable and durable, so prefer those when available.
+If you are on the fence between having haptics or not, you can print the Prototype v4 without servos and add them later.
+
+Check the [printing guides](https://github.com/LucidVR/lucidgloves/wiki/Parts-Printing-Guide) to know how many you need to print and how.


### PR DESCRIPTION
Replaces the misleading readme in lucidgloves-firmware that caused people to install the wrong esp32 servo library with a link to the wiki page for easier maintainability. Also adds a simple readme to the hardware folder for the sake of completeness and to answer some common questions.