### PR TITLE
Add support for smoother force feedback by using writeMicroseconds.

### DIFF
--- a/firmware/lucidgloves-firmware/AdvancedConfig.h
+++ b/firmware/lucidgloves-firmware/AdvancedConfig.h
@@ -48,3 +48,9 @@
 // https://www.arduino.cc/reference/en/libraries/runningmedian/
 #define ENABLE_MEDIAN_FILTER false //use the median of the previous values, helps reduce noise
 #define MEDIAN_SAMPLES 20
+
+// Experimental. Uses micro-second pulse values for servo control instead of degrees.
+#define SERVO_SMOOTH_STEPPING false
+// The driver sends values from 0-1000 today.
+#define FORCE_FEEDBACK_MIN 0
+#define FORCE_FEEDBACK_MAX 1000

--- a/firmware/lucidgloves-firmware/haptics.ino
+++ b/firmware/lucidgloves-firmware/haptics.ino
@@ -6,11 +6,24 @@
   #include "Servo.h"
 #endif
 
+#if SERVO_SMOOTH_STEPPING
+  #define SERVO_MIN MIN_PULSE_WIDTH
+  #define SERVO_MAX MAX_PULSE_WIDTH
+  #define WRITE_FUNCTION(x) writeMicroseconds(x)
+#else
+  #define SERVO_MIN 0
+  #define SERVO_MAX 180
+  #define WRITE_FUNCTION(x) write(x)
+#endif
+
 Servo pinkyServo;
 Servo ringServo;
 Servo middleServo;
 Servo indexServo;
 Servo thumbServo;
+
+// Use a list for easier modification of all servos.
+Servo* servos[5] = { &thumbServo, &indexServo, &middleServo, &ringServo, &pinkyServo };
 
 void setupServoHaptics(){
   pinkyServo.attach(PIN_PINKY_MOTOR);
@@ -20,15 +33,18 @@ void setupServoHaptics(){
   thumbServo.attach(PIN_THUMB_MOTOR);
 }
 
-//static scaling, maps to entire range of servo
-void scaleLimits(int* hapticLimits, float* scaledLimits){
-  for (int i = 0; i < 5; i++){
-    scaledLimits[i] = 180.0f - hapticLimits[i] / 1000.0f * 180.0f;
-  }
+// Re-implimentation of map() using floats. If we need speed in the future swap to the integer
+// based map() function and give up a bit of accuracy.
+inline long scaleLimits(float x, float in_min, float in_max, float out_min, float out_max) {
+  // Map one range to the other.
+  x = (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+
+  // Constrain x to the servo limits. We don't ever want to try to move to 200 degrees.
+  return (long)constrain(x, out_min, out_max);
 }
 
 //dynamic scaling, maps to the limits calibrated from your finger
-void dynScaleLimits(int* hapticLimits, float* scaledLimits){
+void dynScaleLimits(int* hapticLimits, float* scaledLimits) {
   //will be refactored to take min and max as an argument
 
   /* this implementation of dynamic scaling relies on the assumption 
@@ -37,18 +53,15 @@ void dynScaleLimits(int* hapticLimits, float* scaledLimits){
    * Different hardware types may need to handle dynamic scaling differently.
    */
   for (int i = 0; i < sizeof(hapticLimits); i++){
-    scaledLimits[i] = hapticLimits[i] / 1000.0f * 180.0f;
+    scaledLimits[i] = hapticLimits[i] / FORCE_FEEDBACK_MAX * SERVO_MAX;
   }
 }
 
-void writeServoHaptics(int* hapticLimits){
-  float scaledLimits[5];
-  scaleLimits(hapticLimits, scaledLimits);
-  pinkyServo.write(scaledLimits[4]);
-  ringServo.write(scaledLimits[3]);
-  middleServo.write(scaledLimits[2]);
-  indexServo.write(scaledLimits[1]);
-  thumbServo.write(scaledLimits[0]);
+void writeServoHaptics(int* hapticLimits) {
+  for (int i = 0; i < sizeof(servos); ++i) {
+    // Need to convert the input range sent over comm to the correct servo range.
+    servos[i]->WRITE_FUNCTION(scaleLimits(hapticLimits[0], FORCE_FEEDBACK_MIN, FORCE_FEEDBACK_MAX, SERVO_MIN, SERVO_MAX));
+  }
 }
 
 #endif


### PR DESCRIPTION
This will need to be supported in the driver as well to send large values that 0-180. The driver should send a value from 0-4096 to future proof this. Might as well have the firmware scale the value down to what it can support.

On EPS32 the servo library uses micro second pulses from 500-2500, on Arduino it uses 544-2400
https://github.com/jkb-git/ESP32Servo/blob/master/src/ESP32_Servo.h
https://github.com/arduino-libraries/Servo/blob/master/src/Servo.h

This gives us around 2000 steps instead of just the 181 that we get today.

Today we basically do: 
`map(map(hapticLimit, 0, 4096, 0, 180), 0, 180, MICRO_SECOND_MIN, MICRO_SECOND_MAX)`
we should be doing:
`map(hapticLimit, 0, 4096, MICRO_SECOND_MIN, MICRO_SECOND_MAX)`