### PR TITLE
Add "Dynamic Servo Scaling" as Force Feedback Servo Scaling

### DIFF
--- a/firmware/lucidgloves-firmware/MinMaxCalibration.h
+++ b/firmware/lucidgloves-firmware/MinMaxCalibration.h
@@ -1,0 +1,41 @@
+#pragma once
+
+template<typename T>
+struct MinMaxCalibration {
+ public:
+  MinMaxCalibration(T output_min_,T output_max_, bool clamp_) :
+    output_min(output_min_),
+    output_max(output_max_),
+    value_min(output_max_),
+    value_max(output_min_),
+    clamp(clamp_) {}
+
+  void reset() {
+    value_min = output_max;
+    value_max = output_min;
+  }
+
+  void update(T input) {
+    // Either update the min or the max.
+    // We shouldn't ever need to update both.
+    if (input < value_min) value_min = input;
+    if (input > value_max) value_max = input;
+  }
+
+  T calibrate(T input, T input_min, T input_max) const {
+    // This means we haven't had any calibration data yet.
+    // Return a neutral value right in the middle of the output range.
+    if (value_min > value_max) return (output_min + output_max) / 2.0f;
+
+    // Map the input range to the output range.
+    T output = map(input, input_min, input_max, value_min, value_max);
+    return clamp ? constrain(output, output_min, output_max) : output;
+  }
+
+private:
+ T output_min;
+ T output_max;
+ T value_min;
+ T value_max;
+ bool clamp;
+};

--- a/firmware/lucidgloves-firmware/_main.ino
+++ b/firmware/lucidgloves-firmware/_main.ino
@@ -4,6 +4,8 @@
 
 #define CALIBRATION_RANGE { 0, ANALOG_MAX, CLAMP_ANALOG_MAP }
 MinMaxCalibration<int> calibrators[5] = {CALIBRATION_RANGE, CALIBRATION_RANGE, CALIBRATION_RANGE, CALIBRATION_RANGE, CALIBRATION_RANGE};
+// Prevent Arduino IDE from being "helpful" and auto generating this prototype ABOVE the inludes.
+void writeServoHaptics(const MinMaxCalibration<int>* calibrators, const int* hapticLimits);
 
 ICommunication* comm;
 int loops = 0;
@@ -90,7 +92,7 @@ void loop() {
       if (comm->readData(received)){
         int hapticLimits[5];
         decodeData(received, hapticLimits);
-        writeServoHaptics(hapticLimits);
+        writeServoHaptics(calibrators, hapticLimits);
       }
     #endif
     delay(LOOP_TIME);

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -39,11 +39,15 @@ void setupInputs(){
   #endif
 }
 
-int* getFingerPositions(bool calibrating, bool reset){
-  int rawFingers[5] = {NO_THUMB?0:analogRead(PIN_THUMB), analogRead(PIN_INDEX), analogRead(PIN_MIDDLE), analogRead(PIN_RING), analogRead(PIN_PINKY)};
-  static int calibrated[5] = {511,511,511,511,511};
 
-  for (int i = 0; i <5; i++) {
+void getFingerPositions(int* rawFingers){
+  rawFingers[0] = NO_THUMB?0:analogRead(PIN_THUMB);
+  rawFingers[1] = analogRead(PIN_INDEX);
+  rawFingers[2] = analogRead(PIN_MIDDLE);
+  rawFingers[3] = analogRead(PIN_RING);
+  rawFingers[4] = analogRead(PIN_PINKY);
+
+  for (int i = 0; i < 5; i++) {
     #if FLIP_POTS
       rawFingers[i] = ANALOG_MAX - rawFingers[i];
     #endif
@@ -53,21 +57,10 @@ int* getFingerPositions(bool calibrating, bool reset){
       rawFingers[i] = rmSamples[i].getMedian();
     #endif
 
-    // Reset max and mins as needed.
-    if (reset) calibration[i].reset();
-
-    // Put this value into the calibrator.
-    if (calibrating) {
-      #if !CLAMP_FLEXION
-        calibration[i].update(rawFingers[i]);
-      #else
-        calibration[i].update(constrain(rawFingers[i], CLAMP_MIN, CLAMP_MAX));
-      #endif
-    }
-
-    calibrated[i] = calibration[i].calibrate(rawFingers[i], 0, ANALOG_MAX);
+    #if CLAMP_FLEXION
+      rawFingers[i] = constrain(rawFingers[i], CLAMP_MIN, CLAMP_MAX);
+    #endif
   }
-  return calibrated;
 }
 
 int analogReadDeadzone(byte pin){

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -50,7 +50,7 @@
 #define USING_CALIB_PIN false //When PIN_CALIB is shorted (or it's button pushed) it will reset calibration if this is on.
 
 #define USING_FORCE_FEEDBACK false //Force feedback haptics allow you to feel the solid objects you hold
-#define SERVO_SCALING false //dynamic scaling of servo motors
+#define USING_FORCE_FEEDBACK_SCALING false // Experimental. Limit servo range of motion to the calibrated input range.
 
 //PINS CONFIGURATION 
 #if defined(__AVR__)


### PR DESCRIPTION
This change removes that dead code of `dynScaleLimits` and adds in static per finger scaling rates.

The default values are based on approximate sizing of each finger using the middle finger as 1.0 since it is the largest.

Hardcoding this will work for now and be configurable when flashing the FW, but it would be nice to have a comm packet the driver could send to set these values dynamically based on user configuration from the driver UI.