### PR TITLE
Add option to invert servo angles

### DIFF
--- a/firmware/lucidgloves-firmware/haptics.ino
+++ b/firmware/lucidgloves-firmware/haptics.ino
@@ -23,7 +23,11 @@ void setupServoHaptics(){
 //static scaling, maps to entire range of servo
 void scaleLimits(int* hapticLimits, float* scaledLimits){
   for (int i = 0; i < 5; i++){
+#if INVERT_SERVO
+    scaledLimits[i] = hapticLimits[i] / 1000.0f * 180.0f;
+# else
     scaledLimits[i] = 180.0f - hapticLimits[i] / 1000.0f * 180.0f;
+#endif
   }
 }
 

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -51,6 +51,7 @@
 
 #define USING_FORCE_FEEDBACK false //Force feedback haptics allow you to feel the solid objects you hold
 #define SERVO_SCALING false //dynamic scaling of servo motors
+#define INVERT_SERVO false // Reverse the angles sent to the servo
 
 #if defined(ESP32)
   //(This configuration is for ESP32 DOIT V1 so make sure to change if you're on another board)


### PR DESCRIPTION
If your glove construction has a counter-clockwise rotation, you might need to set this to true to change the direction your servos move when going from EXTENDED to RETRACTED