### PR TITLE
Compatibility with ESP32S3

### DIFF
--- a/firmware/lucidgloves-firmware/ConfigUtils.h
+++ b/firmware/lucidgloves-firmware/ConfigUtils.h
@@ -44,6 +44,7 @@ public:
 //Comm
 #define COMM_SERIAL 0   
 #define COMM_BTSERIAL 1 
+#define COMM_BLESERIAL 2 
 
 //Encode
 #define ENCODE_LEGACY 0

--- a/firmware/lucidgloves-firmware/SerialBLECommunication.ino
+++ b/firmware/lucidgloves-firmware/SerialBLECommunication.ino
@@ -12,6 +12,19 @@ class BLESerialCommunication : public ICommunication {
       m_isOpen = false;
     }
 
+    class ServerCallbacks: public NimBLEServerCallbacks {
+      void onConnect(NimBLEServer* pServer) {
+          #ifdef NEOPIXEL
+          neopixelWrite(DEBUG_LED,0,RGB_BRIGHTNESS,0); // Green
+          #endif
+      };
+      void onDisconnect(NimBLEServer* pServer) {
+          #ifdef NEOPIXEL
+          neopixelWrite(DEBUG_LED,0,0,RGB_BRIGHTNESS); // Blue
+          #endif
+      };
+    };
+
     bool isOpen(){
       return m_isOpen;
     }
@@ -20,6 +33,7 @@ class BLESerialCommunication : public ICommunication {
       NimBLEDevice::init(BTSERIAL_DEVICE_NAME);
 
       pServer = NimBLEDevice::createServer();
+      pServer->setCallbacks(new ServerCallbacks());
       NimBLEService *pService = pServer->createService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); //Main service
       NimBLECharacteristic *rxCharacteristic = pService->createCharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E",NIMBLE_PROPERTY::WRITE);
       NimBLECharacteristic *txCharacteristic = pService->createCharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E",NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
@@ -32,6 +46,9 @@ class BLESerialCommunication : public ICommunication {
       #if BT_ECHO
       Serial.begin(SERIAL_BAUD_RATE);
       Serial.println("The device started, now you can pair it with bluetooth!");
+      #endif
+      #ifdef NEOPIXEL
+      neopixelWrite(DEBUG_LED,0,0,RGB_BRIGHTNESS); // Blue
       #endif
       m_isOpen = true;
     }

--- a/firmware/lucidgloves-firmware/SerialBLECommunication.ino
+++ b/firmware/lucidgloves-firmware/SerialBLECommunication.ino
@@ -43,6 +43,7 @@ class BLESerialCommunication : public ICommunication {
             NimBLECharacteristic* qChr = pSvc->getCharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
             if(qChr) {
                 qChr->setValue(String(data));
+                qChr->notify();
             }
         }
       }

--- a/firmware/lucidgloves-firmware/SerialBLECommunication.ino
+++ b/firmware/lucidgloves-firmware/SerialBLECommunication.ino
@@ -62,8 +62,8 @@ class BLESerialCommunication : public ICommunication {
         if(pSvc) {
           NimBLECharacteristic* qChr = pSvc->getCharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
           if(qChr) {
-            String message = qChr->getValue();
-            strcpy(input, message.c_str());
+            //String message = qChr->getValue();
+            strcpy(input, qChr->getValue().c_str());
           }
         }
       }

--- a/firmware/lucidgloves-firmware/SerialBLECommunication.ino
+++ b/firmware/lucidgloves-firmware/SerialBLECommunication.ino
@@ -1,0 +1,73 @@
+//only compiles if BLESerial is set because it won't compile for a non-compatible board
+#if COMMUNICATION == COMM_BLESERIAL
+#include <NimBLEDevice.h>
+#define   CONFIG_BT_NIMBLE_PINNED_TO_CORE   1 //Pins NimBLE to core 1
+static NimBLEServer* pServer;
+class BLESerialCommunication : public ICommunication {
+  private:
+    bool m_isOpen;
+
+  public:
+    BLESerialCommunication() {
+      m_isOpen = false;
+    }
+
+    bool isOpen(){
+      return m_isOpen;
+    }
+
+    void start(){
+      NimBLEDevice::init(BTSERIAL_DEVICE_NAME);
+
+      pServer = NimBLEDevice::createServer();
+      NimBLEService *pService = pServer->createService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); //Main service
+      NimBLECharacteristic *rxCharacteristic = pService->createCharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E",NIMBLE_PROPERTY::WRITE);
+      NimBLECharacteristic *txCharacteristic = pService->createCharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E",NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+      pService->start();
+
+      NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising(); // create advertising instance
+      pAdvertising->addServiceUUID(pService->getUUID()); // tell advertising the UUID of our service
+      pAdvertising->start(); // start advertising
+      
+      #if BT_ECHO
+      Serial.begin(SERIAL_BAUD_RATE);
+      Serial.println("The device started, now you can pair it with bluetooth!");
+      #endif
+      m_isOpen = true;
+    }
+
+    void output(char* data){
+      if(pServer->getConnectedCount()) {
+        NimBLEService* pSvc = pServer->getServiceByUUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
+        if(pSvc) {
+            NimBLECharacteristic* qChr = pSvc->getCharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
+            if(qChr) {
+                qChr->setValue(String(data));
+            }
+        }
+      }
+      //else
+      //vTaskDelay(1); //keep watchdog fed
+      #if BT_ECHO
+      Serial.print(data);
+      Serial.flush();
+      #endif
+    }
+
+    bool readData(char* input){
+      /*byte size = m_SerialBT.readBytesUntil('\n', input, 100);
+      input[size] = NULL;*/
+      if(pServer->getConnectedCount()) {
+        NimBLEService* pSvc = pServer->getServiceByUUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
+        if(pSvc) {
+          NimBLECharacteristic* qChr = pSvc->getCharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
+          if(qChr) {
+            String message = qChr->getValue();
+            strcpy(input, message.c_str());
+          }
+        }
+      }
+      return input != NULL && strlen(input) > 0;
+    }
+};
+#endif

--- a/firmware/lucidgloves-firmware/_main.ino
+++ b/firmware/lucidgloves-firmware/_main.ino
@@ -48,7 +48,11 @@ void setup() {
   pinMode(32, INPUT_PULLUP);
   #endif
   pinMode(DEBUG_LED, OUTPUT);
-  digitalWrite(DEBUG_LED, HIGH);
+  #ifdef NEOPIXEL 
+  neopixelWrite(DEBUG_LED,RGB_BRIGHTNESS,0,0); // Red 
+  #else   
+  digitalWrite(DEBUG_LED, HIGH); 
+  #endif 
   #if COMMUNICATION == COMM_SERIAL
     comm = new SerialCommunication();
   #elif COMMUNICATION == COMM_BTSERIAL

--- a/firmware/lucidgloves-firmware/_main.ino
+++ b/firmware/lucidgloves-firmware/_main.ino
@@ -44,9 +44,7 @@ void getInputs(void* parameter){
 
 int loops = 0;
 void setup() {
-
-  pinMode(32, INPUT_PULLUP);
-  
+ 
   #if COMMUNICATION == COMM_SERIAL
     comm = new SerialCommunication();
   #elif COMMUNICATION == COMM_BTSERIAL

--- a/firmware/lucidgloves-firmware/_main.ino
+++ b/firmware/lucidgloves-firmware/_main.ino
@@ -49,6 +49,8 @@ void setup() {
     comm = new SerialCommunication();
   #elif COMMUNICATION == COMM_BTSERIAL
     comm = new BTSerialCommunication();
+  #elif COMMUNICATION == COMM_BLESERIAL
+    comm = new BLESerialCommunication();
   #endif  
   comm->start();
 

--- a/firmware/lucidgloves-firmware/haptics.ino
+++ b/firmware/lucidgloves-firmware/haptics.ino
@@ -1,7 +1,7 @@
 #if USING_FORCE_FEEDBACK
 
 #if defined(ESP32)
-  #include "ESP32Servo.h"
+  #include <Servo.h>
 #else
   #include "Servo.h"
 #endif
@@ -49,11 +49,19 @@ void dynScaleLimits(int* hapticLimits, float* scaledLimits){
 void writeServoHaptics(int* hapticLimits){
   float scaledLimits[5];
   scaleLimits(hapticLimits, scaledLimits);
-  if(hapticLimits[0] >= 0) thumbServo.write(scaledLimits[0]);
-  if(hapticLimits[1] >= 0) indexServo.write(scaledLimits[1]);
-  if(hapticLimits[2] >= 0) middleServo.write(scaledLimits[2]);
-  if(hapticLimits[3] >= 0) ringServo.write(scaledLimits[3]);
-  if(hapticLimits[4] >= 0) pinkyServo.write(scaledLimits[4]);
+  #if defined(ESP32)
+    if(hapticLimits[0] >= 0) thumbServo.write(PIN_THUMB_MOTOR,scaledLimits[0]);
+    if(hapticLimits[1] >= 0) indexServo.write(PIN_INDEX_MOTOR,scaledLimits[1]);
+    if(hapticLimits[2] >= 0) middleServo.write(PIN_MIDDLE_MOTOR,scaledLimits[2]);
+    if(hapticLimits[3] >= 0) ringServo.write(PIN_RING_MOTOR,scaledLimits[3]);
+    if(hapticLimits[4] >= 0) pinkyServo.write(PIN_PINKY_MOTOR,scaledLimits[4]);
+  #else
+    if(hapticLimits[0] >= 0) thumbServo.write(scaledLimits[0]);
+    if(hapticLimits[1] >= 0) indexServo.write(scaledLimits[1]);
+    if(hapticLimits[2] >= 0) middleServo.write(ecaledLimits[2]);
+    if(hapticLimits[3] >= 0) ringServo.write(scaledLimits[3]);
+    if(hapticLimits[4] >= 0) pinkyServo.write(scaledLimits[4]);
+  #endif
 }
 
 #endif

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -77,7 +77,7 @@ void setupInputs(){
     savedTravel = true;
     loadTravel();
   }
-  if (isSavedIntermediate() && FLEXION_MIXING != MIXING_NONE){ \\ Check to make sure we're even using mixing. If someone had the wrong mixing type set before, this will cause an issue!
+  if (isSavedIntermediate() && FLEXION_MIXING != MIXING_NONE){ // Check to make sure we're even using mixing. If someone had the wrong mixing type set before, this will cause an issue!
     Serial.println("IsSavedIntermediate!");
     savedInter = true;
     loadIntermediate();

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -77,7 +77,7 @@ void setupInputs(){
     savedTravel = true;
     loadTravel();
   }
-  if (isSavedIntermediate()){
+  if (isSavedIntermediate() && FLEXION_MIXING != MIXING_NONE){ \\ Check to make sure we're even using mixing. If someone had the wrong mixing type set before, this will cause an issue!
     Serial.println("IsSavedIntermediate!");
     savedInter = true;
     loadIntermediate();

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -71,12 +71,6 @@ void setupInputs(){
   pinMode(PIN_A_BTN, INPUT_PULLUP);
   pinMode(PIN_B_BTN, INPUT_PULLUP);
 
-  pinMode(PIN_MENU_BTN, INPUT_PULLUP);
-  
-  #if !TRIGGER_GESTURE
-  pinMode(PIN_TRIG_BTN, INPUT_PULLUP);
-  #endif
-
   #if !GRAB_GESTURE
   pinMode(PIN_GRAB_BTN, INPUT_PULLUP);
   #endif
@@ -107,7 +101,7 @@ int analogPinRead(int pin){
     return analogRead(pin);
   }
   #else
-   return analogRead(UNMUX(pin));
+   return analogRead(pin);
   #endif
 }
 

--- a/firmware/lucidgloves-firmware/input.ino
+++ b/firmware/lucidgloves-firmware/input.ino
@@ -219,7 +219,7 @@ void getFingerPositions(bool calibrating, bool reset){
     }
   }
   
-  for (int i = 0; i<NUM_FINGERS; i++){
+  for (int i = 0; i < 2*NUM_FINGERS; i++){
   if (i == target){
     targetFlexionMin = minFingers[i];
     targetFlexionMax = maxFingers[i];

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.faemod
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.faemod
@@ -1,0 +1,164 @@
+/*
+ * LucidGloves Firmware Version 4
+ * Author: Lucas_VRTech - LucidVR
+ * lucidvrtech.com
+ */
+
+#include "ConfigUtils.h"
+#include "AdvancedConfig.h"
+
+
+//This is the configuration file, main structure in _main.ino
+//CONFIGURATION SETTINGS:
+#define ESP32S3 // Hack to workaround pin32 issue
+#define NEOPIXEL //Is the DEBUG_LED a WS2812? 
+#define COMMUNICATION COMM_BLESERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
+//serial over USB
+  #define SERIAL_BAUD_RATE 115200
+  
+//serial over Bluetooth
+  #define BTSERIAL_DEVICE_NAME "lucidgloves-right"
+
+//ANALOG INPUT CONFIG
+#define USING_SPLAY true //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.
+#define USING_MULTIPLEXER false //Whether or not you are using a multiplexer for inputs
+#define FLIP_FLEXION  false  //Flip values from potentiometers (for fingers!) if they are backwards
+#define FLIP_SPLAY true //Flip values for splay
+
+
+//Gesture enables, make false to use button override
+#define TRIGGER_GESTURE true
+#define GRAB_GESTURE    true
+#define PINCH_GESTURE   true
+
+
+//BUTTON INVERT
+//If a button registers as pressed when not and vice versa (eg. using normally-closed switches),
+//you can invert their behaviour here by setting their line to true.
+//If unsure, set to false
+#define INVERT_A false
+#define INVERT_B false
+#define INVERT_JOY false
+#define INVERT_MENU true
+#define INVERT_CALIB false
+//These only apply with gesture button override:
+#define INVERT_TRIGGER true
+#define INVERT_GRAB false
+#define INVERT_PINCH false
+
+
+//joystick configuration
+#define JOYSTICK_BLANK true //make true if not using the joystick
+#define JOY_FLIP_X false
+#define JOY_FLIP_Y false
+#define JOYSTICK_DEADZONE 10 //deadzone in the joystick to prevent drift (in percent)
+
+#define NO_THUMB false //If for some reason you don't want to track the thumb
+
+#define USING_CALIB_PIN true //When PIN_CALIB is shorted (or it's button pushed) it will reset calibration if this is on.
+
+#define USING_FORCE_FEEDBACK true //Force feedback haptics allow you to feel the solid objects you hold
+#define FLIP_FORCE_FEEDBACK true
+#define SERVO_SCALING false //dynamic scaling of servo motors
+
+#if defined(ESP32)
+  //(This configuration is for ESP32 DOIT V1 so make sure to change if you're on another board)
+  //To use a pin on the multiplexer, use MUX(pin). So for example pin 15 on a mux would be MUX(15).
+  #define PIN_PINKY     6 //These 5 are for flexion
+  #define PIN_RING      10
+  #define PIN_MIDDLE    18
+  #define PIN_INDEX     15
+  #define PIN_THUMB     2
+  #define PIN_JOY_X     13
+  #define PIN_JOY_Y     14
+  #define PIN_JOY_BTN   35
+  #define PIN_A_BTN     21 
+  #define PIN_B_BTN     3
+  #define PIN_TRIG_BTN  46 //unused if gesture set
+  #define PIN_GRAB_BTN  48 //unused if gesture set
+  #define PIN_PNCH_BTN  47 //unused if gesture set
+  #define PIN_CALIB     36 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
+  #define DEBUG_LED 37
+  #define PIN_PINKY_MOTOR     42  //used for force feedback
+  #define PIN_RING_MOTOR      41 //^
+  #define PIN_MIDDLE_MOTOR    40 //^
+  #define PIN_INDEX_MOTOR     39 //^
+  #define PIN_THUMB_MOTOR     38 //^
+  #define PIN_MENU_BTN        45
+
+  //Splay pins. Only used for splay tracking gloves. Use MUX(pin) if you are using a multiplexer for it.
+  #define PIN_PINKY_SPLAY  4
+  #define PIN_RING_SPLAY   12
+  #define PIN_MIDDLE_SPLAY 9
+  #define PIN_INDEX_SPLAY  17
+  #define PIN_THUMB_SPLAY  7
+  
+
+  //Select pins for multiplexers, set as needed if using a mux. You can add or remove pins as needed depending on how many select pins your mux needs.
+  #define PINS_MUX_SELECT     NULL,  /*S0 pin*/ \
+                              NULL,  /*S1 pin*/ \
+                              NULL,  /*S2 pin*/ \
+                              NULL   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
+  
+  #define MUX_INPUT NULL  //the input or SIG pin of the multiplexer. This can't be a mux pin.
+
+  //Signal mixing for finger values. Options are: MIXING_NONE, MIXING_SINCOS
+  //For double rotary hall effect sensors use MIXING_SINCOS. For potentiometers use MIXING_NONE.
+  #define FLEXION_MIXING MIXING_SINCOS
+    //Secondary analog pins for mixing flexion values. Only used by MIXING_SINCOS. Use MUX(pin) if you are using a multiplexer for it.
+    #define PIN_PINKY_SECOND     5 
+    #define PIN_RING_SECOND      11
+    #define PIN_MIDDLE_SECOND    8
+    #define PIN_INDEX_SECOND     16
+    #define PIN_THUMB_SECOND     1
+  
+//PINS CONFIGURATION 
+#elif defined(__AVR__)
+  //(This configuration is for Arduino Nano so make sure to change if you're on another board)
+  #define PIN_PINKY     A0
+  #define PIN_RING      A1
+  #define PIN_MIDDLE    A2
+  #define PIN_INDEX     A3
+  #define PIN_THUMB     A4
+  #define PIN_JOY_X     A6
+  #define PIN_JOY_Y     A7
+  #define PIN_JOY_BTN   7 
+  #define PIN_A_BTN     8 
+  #define PIN_B_BTN     9
+  #define PIN_TRIG_BTN  10 //unused if gesture set
+  #define PIN_GRAB_BTN  11 //unused if gesture set
+  #define PIN_PNCH_BTN  12 //unused if gesture set
+  #define PIN_CALIB     13 //button for recalibration
+  #define DEBUG_LED     LED_BUILTIN
+  #define PIN_PINKY_MOTOR     2 //used for force feedback
+  #define PIN_RING_MOTOR      3 //^
+  #define PIN_MIDDLE_MOTOR    4 //^
+  #define PIN_INDEX_MOTOR     5 //^
+  #define PIN_THUMB_MOTOR     6 //^
+  #define PIN_MENU_BTN        8
+
+  //Splay pins. Only used for splay tracking gloves. Use MUX(pin) if you are using a multiplexer for it.
+  #define PIN_PINKY_SPLAY  MUX(10)
+  #define PIN_RING_SPLAY   MUX(11)
+  #define PIN_MIDDLE_SPLAY MUX(12)
+  #define PIN_INDEX_SPLAY  MUX(13)
+  #define PIN_THUMB_SPLAY  MUX(14)
+  
+  //Select pins for multiplexers, set as needed if using a mux. You can add or remove pins as needed depending on how many select pins your mux needs.
+  #define PINS_MUX_SELECT     10,  /*S0 pin*/ \
+                              11,  /*S1 pin*/ \
+                              12,  /*S2 pin*/ \
+                              13   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
+  
+  #define MUX_INPUT A0  //the input or SIG pin of the multiplexer. This can't be a mux pin.
+
+  //Signal mixing for finger values. Options are: MIXING_NONE, MIXING_SINCOS
+  //For double rotary hall effect sensors use MIXING_SINCOS. For potentiometers use MIXING_NONE.
+  #define FLEXION_MIXING MIXING_NONE
+    //Secondary analog pins for mixing. Only used by MIXING_SINCOS. Use MUX(pin) if you are using a multiplexer for it.
+    #define PIN_PINKY_SECOND     MUX(1) 
+    #define PIN_RING_SECOND      MUX(3)
+    #define PIN_MIDDLE_SECOND    MUX(5)
+    #define PIN_INDEX_SECOND     MUX(7)
+    #define PIN_THUMB_SECOND     MUX(9)
+#endif

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -10,7 +10,7 @@
 
 //This is the configuration file, main structure in _main.ino
 //CONFIGURATION SETTINGS:
-#define COMMUNICATION COMM_SERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth)
+#define COMMUNICATION COMM_BLESERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
 //serial over USB
   #define SERIAL_BAUD_RATE 115200
   

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -15,11 +15,11 @@
   #define SERIAL_BAUD_RATE 115200
   
 //serial over Bluetooth
-  #define BTSERIAL_DEVICE_NAME "lucidgloves-left"
+  #define BTSERIAL_DEVICE_NAME "lucidgloves-right"
 
 //ANALOG INPUT CONFIG
-#define USING_SPLAY false //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.
-#define USING_MULTIPLEXER true //Whether or not you are using a multiplexer for inputs
+#define USING_SPLAY true //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.
+#define USING_MULTIPLEXER false //Whether or not you are using a multiplexer for inputs
 #define FLIP_FLEXION  false  //Flip values from potentiometers (for fingers!) if they are backwards
 #define FLIP_SPLAY true //Flip values for splay
 
@@ -37,10 +37,10 @@
 #define INVERT_A false
 #define INVERT_B false
 #define INVERT_JOY false
-#define INVERT_MENU false
+#define INVERT_MENU true
 #define INVERT_CALIB false
 //These only apply with gesture button override:
-#define INVERT_TRIGGER false
+#define INVERT_TRIGGER true
 #define INVERT_GRAB false
 #define INVERT_PINCH false
 
@@ -55,60 +55,60 @@
 
 #define USING_CALIB_PIN true //When PIN_CALIB is shorted (or it's button pushed) it will reset calibration if this is on.
 
-#define USING_FORCE_FEEDBACK false //Force feedback haptics allow you to feel the solid objects you hold
+#define USING_FORCE_FEEDBACK true //Force feedback haptics allow you to feel the solid objects you hold
 #define FLIP_FORCE_FEEDBACK true
 #define SERVO_SCALING false //dynamic scaling of servo motors
 
 #if defined(ESP32)
   //(This configuration is for ESP32 DOIT V1 so make sure to change if you're on another board)
   //To use a pin on the multiplexer, use MUX(pin). So for example pin 15 on a mux would be MUX(15).
-  #define PIN_PINKY     MUX(12) //These 5 are for flexion
-  #define PIN_RING      MUX(9)
-  #define PIN_MIDDLE    MUX(6)
-  #define PIN_INDEX     MUX(3)
-  #define PIN_THUMB     MUX(0)
-  #define PIN_JOY_X     33
-  #define PIN_JOY_Y     25
-  #define PIN_JOY_BTN   26
-  #define PIN_A_BTN     27 
-  #define PIN_B_BTN     14
-  #define PIN_TRIG_BTN  12 //unused if gesture set
-  #define PIN_GRAB_BTN  13 //unused if gesture set
-  #define PIN_PNCH_BTN  23 //unused if gesture set
-  #define PIN_CALIB     32 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
-  #define DEBUG_LED 2
-  #define PIN_PINKY_MOTOR     19  //used for force feedback
-  #define PIN_RING_MOTOR      18 //^
-  #define PIN_MIDDLE_MOTOR    5 //^
-  #define PIN_INDEX_MOTOR     17 //^
-  #define PIN_THUMB_MOTOR     16 //^
-  #define PIN_MENU_BTN        34
+  #define PIN_PINKY     6 //These 5 are for flexion
+  #define PIN_RING      10
+  #define PIN_MIDDLE    18
+  #define PIN_INDEX     15
+  #define PIN_THUMB     2
+  #define PIN_JOY_X     13
+  #define PIN_JOY_Y     14
+  #define PIN_JOY_BTN   35
+  #define PIN_A_BTN     21 
+  #define PIN_B_BTN     3
+  #define PIN_TRIG_BTN  46 //unused if gesture set
+  #define PIN_GRAB_BTN  48 //unused if gesture set
+  #define PIN_PNCH_BTN  47 //unused if gesture set
+  #define PIN_CALIB     36 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
+  #define DEBUG_LED 23
+  #define PIN_PINKY_MOTOR     42  //used for force feedback
+  #define PIN_RING_MOTOR      41 //^
+  #define PIN_MIDDLE_MOTOR    40 //^
+  #define PIN_INDEX_MOTOR     39 //^
+  #define PIN_THUMB_MOTOR     38 //^
+  #define PIN_MENU_BTN        45
 
   //Splay pins. Only used for splay tracking gloves. Use MUX(pin) if you are using a multiplexer for it.
-  #define PIN_PINKY_SPLAY  MUX(14)
-  #define PIN_RING_SPLAY   MUX(11)
-  #define PIN_MIDDLE_SPLAY MUX(8)
-  #define PIN_INDEX_SPLAY  MUX(5)
-  #define PIN_THUMB_SPLAY  MUX(2)
+  #define PIN_PINKY_SPLAY  4
+  #define PIN_RING_SPLAY   12
+  #define PIN_MIDDLE_SPLAY 9
+  #define PIN_INDEX_SPLAY  17
+  #define PIN_THUMB_SPLAY  7
   
 
   //Select pins for multiplexers, set as needed if using a mux. You can add or remove pins as needed depending on how many select pins your mux needs.
-  #define PINS_MUX_SELECT     27,  /*S0 pin*/ \
-                              14,  /*S1 pin*/ \
-                              12,  /*S2 pin*/ \
-                              13   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
+  #define PINS_MUX_SELECT     NULL,  /*S0 pin*/ \
+                              NULL,  /*S1 pin*/ \
+                              NULL,  /*S2 pin*/ \
+                              NULL   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
   
-  #define MUX_INPUT 35  //the input or SIG pin of the multiplexer. This can't be a mux pin.
+  #define MUX_INPUT NULL  //the input or SIG pin of the multiplexer. This can't be a mux pin.
 
   //Signal mixing for finger values. Options are: MIXING_NONE, MIXING_SINCOS
   //For double rotary hall effect sensors use MIXING_SINCOS. For potentiometers use MIXING_NONE.
   #define FLEXION_MIXING MIXING_SINCOS
     //Secondary analog pins for mixing flexion values. Only used by MIXING_SINCOS. Use MUX(pin) if you are using a multiplexer for it.
-    #define PIN_PINKY_SECOND     MUX(13) 
-    #define PIN_RING_SECOND      MUX(10)
-    #define PIN_MIDDLE_SECOND    MUX(7)
-    #define PIN_INDEX_SECOND     MUX(4)
-    #define PIN_THUMB_SECOND     MUX(1)
+    #define PIN_PINKY_SECOND     5 
+    #define PIN_RING_SECOND      11
+    #define PIN_MIDDLE_SECOND    8
+    #define PIN_INDEX_SECOND     16
+    #define PIN_THUMB_SECOND     1
   
 //PINS CONFIGURATION 
 #elif defined(__AVR__)

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -10,17 +10,17 @@
 
 //This is the configuration file, main structure in _main.ino
 //CONFIGURATION SETTINGS:
-#define ESP32S3 // Hack to workaround pin32 issue
-#define COMMUNICATION COMM_BLESERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
+//#define ESP32S3 // Hack to workaround pin32 issue. Uncomment if you have an ESP32S3.
+#define COMMUNICATION COMM_SERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
 //serial over USB
   #define SERIAL_BAUD_RATE 115200
   
 //serial over Bluetooth
-  #define BTSERIAL_DEVICE_NAME "lucidgloves-right"
+  #define BTSERIAL_DEVICE_NAME "lucidgloves-left"
 
 //ANALOG INPUT CONFIG
-#define USING_SPLAY true //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.
-#define USING_MULTIPLEXER false //Whether or not you are using a multiplexer for inputs
+#define USING_SPLAY false //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.
+#define USING_MULTIPLEXER true //Whether or not you are using a multiplexer for inputs
 #define FLIP_FLEXION  false  //Flip values from potentiometers (for fingers!) if they are backwards
 #define FLIP_SPLAY true //Flip values for splay
 
@@ -38,10 +38,10 @@
 #define INVERT_A false
 #define INVERT_B false
 #define INVERT_JOY false
-#define INVERT_MENU true
+#define INVERT_MENU false
 #define INVERT_CALIB false
 //These only apply with gesture button override:
-#define INVERT_TRIGGER true
+#define INVERT_TRIGGER false
 #define INVERT_GRAB false
 #define INVERT_PINCH false
 
@@ -56,60 +56,60 @@
 
 #define USING_CALIB_PIN true //When PIN_CALIB is shorted (or it's button pushed) it will reset calibration if this is on.
 
-#define USING_FORCE_FEEDBACK true //Force feedback haptics allow you to feel the solid objects you hold
+#define USING_FORCE_FEEDBACK false //Force feedback haptics allow you to feel the solid objects you hold
 #define FLIP_FORCE_FEEDBACK true
 #define SERVO_SCALING false //dynamic scaling of servo motors
 
 #if defined(ESP32)
   //(This configuration is for ESP32 DOIT V1 so make sure to change if you're on another board)
   //To use a pin on the multiplexer, use MUX(pin). So for example pin 15 on a mux would be MUX(15).
-  #define PIN_PINKY     6 //These 5 are for flexion
-  #define PIN_RING      10
-  #define PIN_MIDDLE    18
-  #define PIN_INDEX     15
-  #define PIN_THUMB     2
-  #define PIN_JOY_X     13
-  #define PIN_JOY_Y     14
-  #define PIN_JOY_BTN   35
-  #define PIN_A_BTN     21 
-  #define PIN_B_BTN     3
-  #define PIN_TRIG_BTN  46 //unused if gesture set
-  #define PIN_GRAB_BTN  48 //unused if gesture set
-  #define PIN_PNCH_BTN  47 //unused if gesture set
-  #define PIN_CALIB     36 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
-  #define DEBUG_LED 23
-  #define PIN_PINKY_MOTOR     42  //used for force feedback
-  #define PIN_RING_MOTOR      41 //^
-  #define PIN_MIDDLE_MOTOR    40 //^
-  #define PIN_INDEX_MOTOR     39 //^
-  #define PIN_THUMB_MOTOR     38 //^
-  #define PIN_MENU_BTN        45
+  #define PIN_PINKY     MUX(12) //These 5 are for flexion
+  #define PIN_RING      MUX(9)
+  #define PIN_MIDDLE    MUX(6)
+  #define PIN_INDEX     MUX(3)
+  #define PIN_THUMB     MUX(0)
+  #define PIN_JOY_X     33
+  #define PIN_JOY_Y     25
+  #define PIN_JOY_BTN   26
+  #define PIN_A_BTN     27 
+  #define PIN_B_BTN     14
+  #define PIN_TRIG_BTN  12 //unused if gesture set
+  #define PIN_GRAB_BTN  13 //unused if gesture set
+  #define PIN_PNCH_BTN  23 //unused if gesture set
+  #define PIN_CALIB     32 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
+  #define DEBUG_LED 2
+  #define PIN_PINKY_MOTOR     19  //used for force feedback
+  #define PIN_RING_MOTOR      18 //^
+  #define PIN_MIDDLE_MOTOR    5 //^
+  #define PIN_INDEX_MOTOR     17 //^
+  #define PIN_THUMB_MOTOR     16 //^
+  #define PIN_MENU_BTN        34
 
   //Splay pins. Only used for splay tracking gloves. Use MUX(pin) if you are using a multiplexer for it.
-  #define PIN_PINKY_SPLAY  4
-  #define PIN_RING_SPLAY   12
-  #define PIN_MIDDLE_SPLAY 9
-  #define PIN_INDEX_SPLAY  17
-  #define PIN_THUMB_SPLAY  7
+  #define PIN_PINKY_SPLAY  MUX(14)
+  #define PIN_RING_SPLAY   MUX(11)
+  #define PIN_MIDDLE_SPLAY MUX(8)
+  #define PIN_INDEX_SPLAY  MUX(5)
+  #define PIN_THUMB_SPLAY  MUX(2)
   
 
   //Select pins for multiplexers, set as needed if using a mux. You can add or remove pins as needed depending on how many select pins your mux needs.
-  #define PINS_MUX_SELECT     NULL,  /*S0 pin*/ \
-                              NULL,  /*S1 pin*/ \
-                              NULL,  /*S2 pin*/ \
-                              NULL   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
+  #define PINS_MUX_SELECT     27,  /*S0 pin*/ \
+                              14,  /*S1 pin*/ \
+                              12,  /*S2 pin*/ \
+                              13   /*S3 pin (if your mux is 3-bit like 74HC4051 then you can remove this line and the backslash before it.)*/
   
-  #define MUX_INPUT NULL  //the input or SIG pin of the multiplexer. This can't be a mux pin.
+  #define MUX_INPUT 35  //the input or SIG pin of the multiplexer. This can't be a mux pin.
 
   //Signal mixing for finger values. Options are: MIXING_NONE, MIXING_SINCOS
   //For double rotary hall effect sensors use MIXING_SINCOS. For potentiometers use MIXING_NONE.
   #define FLEXION_MIXING MIXING_SINCOS
     //Secondary analog pins for mixing flexion values. Only used by MIXING_SINCOS. Use MUX(pin) if you are using a multiplexer for it.
-    #define PIN_PINKY_SECOND     5 
-    #define PIN_RING_SECOND      11
-    #define PIN_MIDDLE_SECOND    8
-    #define PIN_INDEX_SECOND     16
-    #define PIN_THUMB_SECOND     1
+    #define PIN_PINKY_SECOND     MUX(13) 
+    #define PIN_RING_SECOND      MUX(10)
+    #define PIN_MIDDLE_SECOND    MUX(7)
+    #define PIN_INDEX_SECOND     MUX(4)
+    #define PIN_THUMB_SECOND     MUX(1)
   
 //PINS CONFIGURATION 
 #elif defined(__AVR__)

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -11,6 +11,7 @@
 //This is the configuration file, main structure in _main.ino
 //CONFIGURATION SETTINGS:
 #define ESP32S3 // Hack to workaround pin32 issue
+#define NEOPIXEL //Is the DEBUG_LED a WS2812? 
 #define COMMUNICATION COMM_BLESERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
 //serial over USB
   #define SERIAL_BAUD_RATE 115200
@@ -77,7 +78,7 @@
   #define PIN_GRAB_BTN  48 //unused if gesture set
   #define PIN_PNCH_BTN  47 //unused if gesture set
   #define PIN_CALIB     36 //button for recalibration (You can set this to GPIO0 to use the BOOT button, but only when using Bluetooth.)
-  #define DEBUG_LED 23
+  #define DEBUG_LED 37
   #define PIN_PINKY_MOTOR     42  //used for force feedback
   #define PIN_RING_MOTOR      41 //^
   #define PIN_MIDDLE_MOTOR    40 //^

--- a/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
+++ b/firmware/lucidgloves-firmware/lucidgloves-firmware.ino
@@ -10,6 +10,7 @@
 
 //This is the configuration file, main structure in _main.ino
 //CONFIGURATION SETTINGS:
+#define ESP32S3 // Hack to workaround pin32 issue
 #define COMMUNICATION COMM_BLESERIAL //Which communication protocol to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_BLESERIAL (BLE Serial, using Nordic UART Service)
 //serial over USB
   #define SERIAL_BAUD_RATE 115200


### PR DESCRIPTION
I've made changes necessary to work with ESP32S3 boards, primarily the Fae Mod board. It provides the option to use BLE serial (implemented using the Nordic UART Service standard), and it switches out ESP32Servo for ESP32-ESP32S2-AnalogWrite, because ESP32Servo can only control one servo on the ESP32S3.