### PR TITLE
Add WIFISerialCommunication The Second

### DIFF
--- a/firmware/lucidgloves-firmware/Config.h
+++ b/firmware/lucidgloves-firmware/Config.h
@@ -15,10 +15,10 @@
 
 // serial over WIFI
 #if COMMUNICATION == COMM_WIFISERIAL
-const char *ssid = "Your_Wifi_SSID";
-const char *password = "Your_Wifi_Password";
-const char *host = "Your_host_ip";
-const int port = 65432; // port of the tcp server
+#define ssid "Your_Wifi_SSID";
+#define password "Your_Wifi_Password";
+#define host "Your_host_ip";
+#define port 65432; // port of the tcp server
 #endif
 
 //ANALOG INPUT CONFIG

--- a/firmware/lucidgloves-firmware/Config.h
+++ b/firmware/lucidgloves-firmware/Config.h
@@ -6,12 +6,20 @@
 
 //This is the configuration file, main structure in _main.ino
 //CONFIGURATION SETTINGS:
-#define COMMUNICATION COMM_SERIAL //Which communication to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth)
+#define COMMUNICATION COMM_SERIAL //Which communication to use. Options are: COMM_SERIAL (usb), COMM_BTSERIAL (bluetooth), COMM_WIFISERIAL (wifi)
 //serial over USB
   #define SERIAL_BAUD_RATE 115200
   
 //serial over Bluetooth
   #define BTSERIAL_DEVICE_NAME "lucidgloves-left"
+
+// serial over WIFI
+#if COMMUNICATION == COMM_WIFISERIAL
+const char *ssid = "Your_Wifi_SSID";
+const char *password = "Your_Wifi_Password";
+const char *host = "Your_host_ip";
+const int port = 65432; // port of the tcp server
+#endif
 
 //ANALOG INPUT CONFIG
 #define USING_SPLAY false //whether or not your glove tracks splay. - tracks the side to side "wag" of fingers. Requires 5 more inputs.

--- a/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.cpp
+++ b/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.cpp
@@ -1,0 +1,61 @@
+#include "WIFISerialCommunication.h"
+// only compiles if WIFISerial is set because it won't compile for a non-compatible board
+#if COMMUNICATION == COMM_WIFISERIAL
+
+void WIFISerialCommunication::connect()
+{
+    while (!client.connect(host, port)) // blocks thread until connected
+        delay(500);
+    Serial.print("Connected to Server at" + String(client.localIP()) + ":" + String(client.localPort()));
+}
+
+
+WIFISerialCommunication::WIFISerialCommunication()
+{
+    m_isOpen = false;
+}
+
+bool WIFISerialCommunication::isOpen()
+{
+    return m_isOpen;
+}
+
+void WIFISerialCommunication::start()
+{
+    Serial.begin(SERIAL_BAUD_RATE);
+    WiFi.begin(ssid, password);
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        delay(1000);
+        Serial.println("Connecting to WiFi...");
+    }
+    m_isOpen = true;
+    Serial.println("Connected to WiFi");
+
+    connect();
+}
+void WIFISerialCommunication::output(char *data)
+{
+    if (!client.connected())
+    {
+        Serial.println("Client not connected, attempting reconnect");
+        connect();
+    }
+    client.println(data);
+}
+
+bool WIFISerialCommunication::readData(char *input)
+{
+    if (!client.connected())
+    {
+        Serial.println("Client not connected, attempting reconnect");
+        connect();
+    }
+    String message = client.readStringUntil('\n');
+    //  String message = client.readStringUntil('\n', input, 100);
+    // input[size] = NULL;
+    strcpy(input, message.c_str());
+
+    return input != NULL && strlen(input) > 0;
+}
+#endif

--- a/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.h
+++ b/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "ICommunication.h"
+#include "../../Config.h"
+
+#if COMMUNICATION == COMM_WIFISERIAL
+#include <WiFi.h>
+#include <HTTPClient.h>
+
+private:
+    bool m_isOpen;
+    WiFiClient client;
+
+    void connect();
+
+public:
+    WIFISerialCommunication();
+
+    bool isOpen();
+
+    void start();
+
+    void output(char *data);
+
+    bool readData(char *input);
+};
+#endif

--- a/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.h
+++ b/firmware/lucidgloves-firmware/src/Communication/WIFISerialCommunication.h
@@ -6,6 +6,7 @@
 #include <WiFi.h>
 #include <HTTPClient.h>
 
+class WIFISerialCommunication : public ICommunication {
 private:
     bool m_isOpen;
     WiFiClient client;
@@ -15,12 +16,12 @@ private:
 public:
     WIFISerialCommunication();
 
-    bool isOpen();
+    bool isOpen() override;
 
-    void start();
+    void start() override;
 
-    void output(char *data);
+    void output(char *data) override;
 
-    bool readData(char *input);
+    bool readData(char *input) override;
 };
 #endif

--- a/firmware/lucidgloves-firmware/src/Main.cpp
+++ b/firmware/lucidgloves-firmware/src/Main.cpp
@@ -24,6 +24,9 @@ void Main::setup() {
     comm = new SerialCommunication();
   #elif COMMUNICATION == COMM_BTSERIAL
     comm = new BTSerialCommunication();
+  #elif COMMUNICATION == COMM_WIFISERIAL
+    comm = new WIFISerialCommunication();
+  #endif
   #else
     #error "Communication not set."
   #endif 

--- a/firmware/lucidgloves-firmware/src/Main.cpp
+++ b/firmware/lucidgloves-firmware/src/Main.cpp
@@ -26,7 +26,6 @@ void Main::setup() {
     comm = new BTSerialCommunication();
   #elif COMMUNICATION == COMM_WIFISERIAL
     comm = new WIFISerialCommunication();
-  #endif
   #else
     #error "Communication not set."
   #endif 

--- a/firmware/lucidgloves-firmware/src/Util/ConfigUtils.h
+++ b/firmware/lucidgloves-firmware/src/Util/ConfigUtils.h
@@ -37,6 +37,7 @@ public:
 //Comm
 #define COMM_SERIAL 0   
 #define COMM_BTSERIAL 1 
+#define COMM_WIFISERIAL 2
 
 //Encode
 #define ENCODE_LEGACY 0

--- a/firmware/lucidgloves-firmware/src/Util/ConfigUtils.h
+++ b/firmware/lucidgloves-firmware/src/Util/ConfigUtils.h
@@ -2,6 +2,8 @@
 //These shouldn't need to be changed.
 
 #pragma once
+#ifndef CONFIGUTILS_H
+#define CONFIGUTILS_H
 #include <mutex>
 #include <condition_variable>
 #include <queue>
@@ -56,3 +58,5 @@ public:
 #define INTERFILTER_NONE 0
 #define INTERFILTER_LIMITS 1
 #define INTERFILTER_ALL 2
+
+#endif


### PR DESCRIPTION
Adds WIFISerial Communication for the gloves.
Connects to TCP Server running on host pc. Currently needs a TCP to COM Reroute to work (e.g. [Reroute Server](https://github.com/REXXER301/TCP-COM-Reroute)), until native wifi support is added to the opengloves driver directly.
Adds glove-sided support for #4 
Also closes #106 