### PR TITLE
Add Config.h include to DataStructs.h

### DIFF
--- a/firmware/lucidgloves-firmware/src/Util/DataStructs.h
+++ b/firmware/lucidgloves-firmware/src/Util/DataStructs.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../AdvancedConfig.h"
+#include "../../Config.h"
 
 const char* const SPECIAL_COMMANDS[] = {
     "SaveInter",


### PR DESCRIPTION
USING_SPLAY is defined in Config.h, so we need to include it so we can check if it's defined. Otherwise there is no splay in OutboundData and the program fails to compile when USING_SPLAY is true